### PR TITLE
Corrected the constraints as sample variance needs @ least 2 values

### DIFF
--- a/latentsafesets/policy/cem_policy.py
+++ b/latentsafesets/policy/cem_policy.py
@@ -98,7 +98,7 @@ class CEMSafeSetPolicy(Policy):
                 num_constraint_satisfying = sum(values > -1e5)
                 iter_num_elites = min(num_constraint_satisfying, self.num_elites)
 
-                if num_constraint_satisfying == 0:
+                if num_constraint_satisfying <= 1:
                     reset_count += 1
                     act_ss_thresh *= self.safe_set_thresh_mult
                     if reset_count > self.safe_set_thresh_mult_iters:


### PR DESCRIPTION
Found when running the SimplePointBot example I kept getting a ValueError with following Traceback:

```
Traceback (most recent call last):
  File "/home/quessy/Dev/safe-learning/scripts/mpc_learning.py", line 83, in <module>
    action = policy.act(obs / 255)
  File "/home/quessy/miniconda3/envs/safe-env/lib/python3.10/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/quessy/Dev/safe-learning/latentsafesets/policy/cem_policy.py", line 124, in act
    predictions = self.dynamics_model.predict(emb, action_samples, already_embedded=True)
  File "/home/quessy/Dev/safe-learning/latentsafesets/modules/pets_dynamics.py", line 122, in predict
    next_emb = model.get_next_emb(running_emb, act_tiled)
  File "/home/quessy/Dev/safe-learning/latentsafesets/modules/pets_dynamics.py", line 194, in get_next_emb
    dist = self(emb, acs)
  File "/home/quessy/miniconda3/envs/safe-env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/quessy/Dev/safe-learning/latentsafesets/modules/pets_dynamics.py", line 176, in forward
    dist = torch.distributions.normal.Normal(delta_normalized_mean, delta_normalized_std)
  File "/home/quessy/miniconda3/envs/safe-env/lib/python3.10/site-packages/torch/distributions/normal.py", line 50, in __init__
    super(Normal, self).__init__(batch_shape, validate_args=validate_args)
  File "/home/quessy/miniconda3/envs/safe-env/lib/python3.10/site-packages/torch/distributions/distribution.py", line 55, in __init__
    raise ValueError(
ValueError: Expected parameter loc (Tensor of shape (20000, 32)) of distribution Normal(loc: torch.Size([20000, 32]), scale: torch.Size([20000, 32])) to satisfy the constraint Real(), but found invalid values:
tensor([[nan, nan, nan,  ..., nan, nan, nan],
        [nan, nan, nan,  ..., nan, nan, nan],
        [nan, nan, nan,  ..., nan, nan, nan],
        ...,
        [nan, nan, nan,  ..., nan, nan, nan],
        [nan, nan, nan,  ..., nan, nan, nan],
        [nan, nan, nan,  ..., nan, nan, nan]], device='cuda:0')
```

This seems to fix it as I think the action variance was trying to get it from one value but we need at least 2.